### PR TITLE
PHP_BINDIR is not working on windows

### DIFF
--- a/src/Commands/Common/StatusCommand.php
+++ b/src/Commands/Common/StatusCommand.php
@@ -55,7 +55,7 @@ class StatusCommand extends PwConnector
 
         $envStatus = [
             ['PHP version', PHP_VERSION],
-            ['PHP binary', PHP_BINDIR],
+            ['PHP binary', PHP_BINARY],
             ['MySQL version', $this->getMySQLVersion()]
         ];
 


### PR DESCRIPTION
PHP_BINARY works well. If you want to get the directory here instead of the fullpath, wrap a dirname() around it. :)
