### PR TITLE
Module:Download – add possibility to download module from github

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ $ wireshell mod:download {module-name},{module-name}
 
 Downloads a module.
 
+Available option:
+
+```
+$ wireshell mod:download {module-name} --github={username/repo_name} --branch={branch}
+```
+
+Optional: Download module from github if it doesn't exists in ProcessWire module directory or if you need a specific branch. Default branch is master.
+
+
 **Alias:** `$ wireshell m:dl`
 
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Available option:
 $ wireshell mod:download {module-name} --github={username/repo_name} --branch={branch}
 ```
 
-Optional: Download module from github if it doesn't exist in ProcessWire module directory or if you need a specific branch. Default branch is master.
+Optional: Download module from github if it doesn't exists in ProcessWire module directory or if you need a specific branch. Default branch is master.
 
 
 **Alias:** `$ wireshell m:dl`
@@ -177,7 +177,7 @@ $ wireshell mod:disable --rm {module-name}
 
 Disables, uninstalls and deletes a module. 
 
-**Alias:** `$ wireshell m:d`
+**Alias:** `$ wireshell m:dis`
 
 #### Show Version
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Available option:
 $ wireshell mod:download {module-name} --github={username/repo_name} --branch={branch}
 ```
 
-Optional: Download module from github if it doesn't exists in ProcessWire module directory or if you need a specific branch. Default branch is master.
+Optional: Download module from github if it doesn't exist in ProcessWire module directory or if you need a specific branch. Default branch is master.
 
 
 **Alias:** `$ wireshell m:dl`

--- a/src/Commands/Module/ModuleDisableCommand.php
+++ b/src/Commands/Module/ModuleDisableCommand.php
@@ -24,7 +24,7 @@ class ModuleDisableCommand extends PwConnector
     {
         $this
             ->setName('module:disable')
-            ->setAliases(['m:d'])
+            ->setAliases(['m:dis'])
             ->setDescription('Disable provided module(s)')
             ->addArgument('modules', InputOption::VALUE_REQUIRED, 'Provide one or more module class name, comma separated: Foo,Bar')
             ->addOption('rm', null, InputOption::VALUE_NONE, 'Remove module');
@@ -47,7 +47,7 @@ class ModuleDisableCommand extends PwConnector
                 $output->writeln("Module {$module} <comment>uninstalled</comment> successfully.");
 
                 // remove module
-                if ($input->getOption('rm') === true && is_dir(wire('config')->paths->MobileDetect)) {
+                if ($input->getOption('rm') === true && is_dir(wire('config')->paths->$module)) {
                     if ($this->recurseRmdir(wire('config')->paths->$module)) {
                         $output->writeln("Module {$module} was <comment>removed</comment> successfully.");
                     } else {


### PR DESCRIPTION
Optional: Download module from github if it doesn't exist in ProcessWire module directory or if you need a specific branch. Default branch is master.

```
$ wireshell mod:download {module-name} --github={username/repo_name} --branch={branch}
$ wireshell mod:download Validator --github=justonestep/processwire-validator --branch=develop
```

**Edit:**
I changed alias `m:d` to `m:dis` to prevent invalid argument exception.

```
[InvalidArgumentException]
Command "m:d" is ambiguous (module:download, module:disable).
```

And I removed another little mistake of mine in ModuleDisableCommand:

```
-  if ($input->getOption('rm') === true && is_dir(wire('config')->paths->MobileDetect)) {
+  if ($input->getOption('rm') === true && is_dir(wire('config')->paths->$module)) {
```
