### PR TITLE
removed unnecesary check of !empty.

### DIFF
--- a/src/Commands/Field/FieldCloneCommand.php
+++ b/src/Commands/Field/FieldCloneCommand.php
@@ -55,7 +55,7 @@ class FieldCloneCommand extends PwConnector
 
         $clone = $fields->clone($fieldToClone);
 
-        if (!empty($input->getOption('name'))) {
+        if ($input->getOption('name')) {
             $clone->name = $input->getOption('name');
             $clone->label = ucfirst($input->getOption('name'));
             $clone->save();


### PR DESCRIPTION
see 
http://stackoverflow.com/questions/1075534/cant-use-method-return-value-in-write-context/4328049#4328049

for explanation.
