### PR TITLE
Make useremail optional in new command

### DIFF
--- a/src/Commands/Common/NewCommand.php
+++ b/src/Commands/Common/NewCommand.php
@@ -95,7 +95,7 @@ class NewCommand extends Command {
       ->addOption('adminUrl', null, InputOption::VALUE_REQUIRED, 'Admin url')
       ->addOption('username', null, InputOption::VALUE_REQUIRED, 'Admin username')
       ->addOption('userpass', null, InputOption::VALUE_REQUIRED, 'Admin password')
-      ->addOption('useremail', null, InputOption::VALUE_REQUIRED, 'Admin email address')
+      ->addOption('useremail', null, InputOption::VALUE_OPTIONAL, 'Admin email address')
       ->addOption('profile', null, InputOption::VALUE_REQUIRED, 'Default site profile: `path/to/profile.zip` OR one of `beginner, blank, classic, default, languages`')
       ->addOption('src', null, InputOption::VALUE_REQUIRED, 'Path to pre-downloaded folder, zip or tgz: `path/to/src`')
       ->addOption('sha', null, InputOption::VALUE_REQUIRED, 'Download specific commit')


### PR DESCRIPTION
I almost never add admin mail. It is optional in default PW installer. I propose make it optional in wireshell also.

I have changed one constant, but not sure it is enough. Please check)